### PR TITLE
Fix Respawn, Upgrade, and Die cycle

### DIFF
--- a/src/abstractRobot/robot.h
+++ b/src/abstractRobot/robot.h
@@ -9,14 +9,9 @@
 using namespace std;
 
 
-enum DeadState {
-    Respawn, Dead
-};
-
-
 class Robot {
 public:
-    virtual DeadState die() = 0;
+    virtual void die() = 0;
 
     virtual string getName() const = 0;
     virtual char getSymbol() const = 0;

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -384,13 +384,18 @@ void Environment::applyRobotUpgrades() {
             newRobot->insertNewUpgrade(upgrade);
             robotPtr = newRobot;
         }
+
+        // Tell robots the upgrades are complete
+        robotPtr->notifyUpgradesCompleted();
     }
-        robotsToUpgrade.clear();
+
+    // Clear out robotToUpgrades set
+    robotsToUpgrade.clear();
 }
 
 void Environment::applyRobotDie() {
-    auto it = robotList.begin();
-    for (; it != robotList.end(); it++) {
+    // Notice there's no increment here
+    for (auto it = robotList.begin(); it != robotList.end(); ) {
         LivingState state = it->get()->getLivingState();
 
         switch (state) {
@@ -405,12 +410,11 @@ void Environment::applyRobotDie() {
                 respawnQueue.push(move(*it));
                 it = robotList.erase(it);
 
-                if (it == robotList.end())
-                    return;
-                break;
-
             // Skip alive robots
+            // Increment is done here
+            // since the operations above will automatically set the next iterator
             case Alive:
+                it++;
                 continue;
         }
     }

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -87,6 +87,7 @@ void Environment::gameLoop() {
             gameOver();
         }
     logger->log("Steps finished");
+    step++;
     }
     gameOver();
 }
@@ -373,8 +374,6 @@ void Environment::applyRobotUpgrades() {
                 newRobot = new class TrackBot(robotPtr);
             }
 
-
-
             // Destroy the old GenericRobot, and switch to the new robot
             // Using iterator allow us to edit in-place, so we don't have to push it into robotList
             robotIterator->reset(newRobot);
@@ -386,8 +385,7 @@ void Environment::applyRobotUpgrades() {
             robotPtr = newRobot;
         }
 
-        // Tell robots the upgrades are complete
-        robotPtr->notifyUpgradesCompleted();
+        robotPtr->setPosition(Vector2D(0,0));
     }
 
     // Clear out robotToUpgrades set

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -68,20 +68,12 @@ void Environment::gameLoop() {
 
         for (unique_ptr<GenericRobot>& robot : robotList) {
             // Skip dead robot
-            if (robot->getIsDead())
+            if (robot->isDead())
                 continue;
 
             logger->log(robot->getName() + "'s turn");
             printMap();
-            // Only act if the robot is still in the list (not killed this turn)
-            if (find_if(robotList.begin(), robotList.end(),
-                        [robot](const unique_ptr<GenericRobot> &ptr)
-                        { return ptr.get() == robot; }) != robotList.end())
-            {
-                robot->thinkAndExecute();
-            robot->logUpgrades();
-                this_thread::sleep_for(chrono::milliseconds(robotActionInterval));
-            }
+            robot->thinkAndExecute();
 
             if (robotList.size() == 1)
             {
@@ -92,6 +84,7 @@ void Environment::gameLoop() {
             step++;
             this_thread::sleep_for(chrono::milliseconds(stepInterval));
         }
+    logger->log("Steps finished");
     }
     gameOver();
 }
@@ -124,16 +117,9 @@ bool Environment::isRobotHere(Vector2D positionToCheck) const {
 GenericRobot* Environment::getRobotAtPosition(Vector2D positionToCheck) const {
     for (const unique_ptr<GenericRobot> &robot : this->robotList) {
         // Skip dead robots
-        if (robot->getIsDead())
+        if (robot->isDead())
             continue;
 
-    return false;
-}
-
-GenericRobot *Environment::getRobotAtPosition(Vector2D positionToCheck) const
-{
-    for (const unique_ptr<GenericRobot> &robot : this->robotList)
-    {
         if (robot->getPosition() == positionToCheck)
             // To return the raw pointer to the object, use get()
             // DO NOT RETURN THE unique_ptr ITSELF
@@ -148,12 +134,11 @@ bool Environment::isPositionAvailable(Vector2D positionToCheck) const {
     return !isRobotHere(positionToCheck) && isWithinBounds(positionToCheck);
 }
 
-bool Environment::isWithinBounds(Vector2D positionToCheck) const
-{
-    if (positionToCheck.x > dimension.x || positionToCheck.x < 0)
+bool Environment::isWithinBounds(Vector2D positionToCheck) const {
+    if(positionToCheck.x > dimension.x || positionToCheck.x < 0)
         return false;
 
-    if (positionToCheck.y > dimension.y || positionToCheck.y < 0)
+    if(positionToCheck.y > dimension.y || positionToCheck.y < 0)
         return false;
 
     return true;
@@ -317,26 +302,11 @@ void Environment::notifyKill(GenericRobot *killer, GenericRobot *victim, DeadSta
         // If already added before (e.g: multiple kills on 1 round),
         // the set data structure will ensure no duplication
         robotsToUpgrade.insert(killerIterator);
-
-    // If respawn move to respawn queue, else just delete urself lol
-
-    switch (deadState) {
-        case DeadState::Respawn:
-            logger->log("Put " + victimIterator->get()->getName() + " into the respawn queue");
-            // respawnQueue.push(move(*victimIterator));
-        break;
-
-        case DeadState::Dead:
-            logger->log(victimIterator->get()->getName() + " won't respawn anymore");
-        break;
-    }
 }
 
-RobotPtrIterator Environment::getRobotIterator(GenericRobot *robot)
-{
-    for (int i = 0; i < robotList.size(); i++)
-    {
-        if (robotList[i].get() == robot)
+RobotPtrIterator Environment::getRobotIterator(GenericRobot* robot) {
+    for (int i = 0; i < robotList.size(); i++) {
+        if(robotList[i].get() == robot)
             return robotList.begin() + i;
     }
 
@@ -430,7 +400,7 @@ vector<GenericRobot*> Environment::getAllRobots() const {
     vector<GenericRobot*> result;
 
     for (const unique_ptr<GenericRobot>& robot : robotList) {
-        if (!robot->getIsDead())
+        if (!robot->isDead())
             result.push_back(robot.get());
     }
 

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -1,5 +1,4 @@
 #include "environment.h"
-#include "abstractRobot/robot.h"
 #include "genericRobot.h"
 #include "upgradeBots.h"
 #include "vector2d.h"
@@ -387,16 +386,32 @@ void Environment::applyRobotUpgrades() {
         robotsToUpgrade.clear();
 }
 
+void Environment::applyRobotDie() {
+    for (auto it = robotList.begin(); it != robotList.end(); it++) {
+        LivingState state = it->get()->getLivingState();
 
-void Environment::applyRobotRespawn()
-{
+        switch (state) {
+            case Dead:
+                // Erasing a vector's element will mess with the ordering of the element
+                // erase() will return the new iterator for the next element
+                // set the current iterator to the return value to avoid skipping / corruption
+                it = robotList.erase(it);
+                break;
+
+            case PendingRespawn:
+                respawnQueue.push(move(*it));
+                it = robotList.erase(it);
+                break;
+
+            case Alive:
+                logger->error("Somehow robot is still alive");
+                exit(1);
+            break;
+        }
+    }
 }
 
-void Environment::applyRobotDie()
-{
-}
-
-vector<GenericRobot*> Environment::getAllRobots() const {
+const vector<GenericRobot*> Environment::getAllAvailableRobots() const {
     vector<GenericRobot*> result;
 
     for (const unique_ptr<GenericRobot>& robot : robotList) {

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -425,7 +425,7 @@ void Environment::applyRobotRespawn() {
     // Make the robot alive again
     robotUniquePtr->notifyRespawn();
 
-    robotList.push_back(robotUniquePtr);
+    robotList.push_back(move(robotUniquePtr));
 
     // remove the first element
     respawnQueue.pop();

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -407,8 +407,11 @@ void Environment::applyRobotDie() {
                 break;
 
             case PendingRespawn:
+                // We use move() here, since we want to mark a transfer of ownership
+                // from robotList to respawnQueue;
                 respawnQueue.push(move(*it));
                 it = robotList.erase(it);
+                break;
 
             // Skip alive robots
             // Increment is done here
@@ -438,6 +441,7 @@ void Environment::applyRobotRespawn() {
     // Make the robot alive again
     robotUniquePtr->notifyRespawn();
 
+    // Re-transfer ownership back to robotList
     robotList.push_back(move(robotUniquePtr));
 
     // remove the first element

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -422,6 +422,9 @@ void Environment::applyRobotRespawn() {
     GenericRobot* resettedRobotPtr = new GenericRobot(*robotUniquePtr);
     robotUniquePtr.reset(resettedRobotPtr);
 
+    // Make the robot alive again
+    robotUniquePtr->notifyRespawn();
+
     robotList.push_back(robotUniquePtr);
 
     // remove the first element

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -176,6 +176,8 @@ void Environment::printMap() const
                 bool found = false;
                 for (const unique_ptr<GenericRobot> &robot : robotList)
                 {
+                    if (robot->isDead())
+                        continue;
                     if (robot->getPosition() == pos)
                     {
                         ss << robot->getSymbol() << " ";

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -5,7 +5,6 @@
 
 #include <memory>
 #include <random>
-#include <algorithm>
 #include <sstream>
 
 // Needed for sleep function
@@ -288,7 +287,7 @@ void Environment::clearLineMarks()
         }
     }
 }
-void Environment::notifyKill(GenericRobot *killer, GenericRobot *victim, DeadState deadState)
+void Environment::notifyKill(GenericRobot *killer, GenericRobot *victim)
 {
     RobotPtrIterator victimIterator = getRobotIterator(victim);
     RobotPtrIterator killerIterator = getRobotIterator(killer);
@@ -499,7 +498,7 @@ void Environment::printwelcomemessage() const
     ss << "##                                                                                                        ##\n";
     ss << ".++######################################################################################################++.\n";
     logger->log(ss.str());
-
+}
 // void Environment::printwelcomemessage() const {
 //     cout << "        __   __  ___  _______ ___      ______   ______  ___      ___  _______      ___________ ______       \n";
 //     cout << "       |\"  |/  \\|  \"|/\"     |\"  |    /\" _  \"\\ /    \" \\|\"  \\    /\"  |/\"     \"|    (\"     _   \")    \" \\      \n";

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -135,10 +135,10 @@ bool Environment::isPositionAvailable(Vector2D positionToCheck) const {
 }
 
 bool Environment::isWithinBounds(Vector2D positionToCheck) const {
-    if(positionToCheck.x > dimension.x || positionToCheck.x < 0)
+    if(positionToCheck.x >= dimension.x || positionToCheck.x < 0)
         return false;
 
-    if(positionToCheck.y > dimension.y || positionToCheck.y < 0)
+    if(positionToCheck.y >= dimension.y || positionToCheck.y < 0)
         return false;
 
     return true;

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -62,7 +62,6 @@ void Environment::gameLoop() {
     while (maxStep > step) {
         logger->log("Round " + to_string(step));
         logger->log("Applying robot upgrades");
-        applyRobotUpgrades();
 
         applyRobotRespawn();
 
@@ -80,6 +79,7 @@ void Environment::gameLoop() {
             );
         }
 
+        applyRobotUpgrades();
         applyRobotDie();
 
         if (robotList.size() == 1) {

--- a/src/environment.h
+++ b/src/environment.h
@@ -88,7 +88,7 @@ public:
     void gameLoop();
     void gameOver();
 
-    void notifyKill(GenericRobot* killer, GenericRobot* victim, DeadState deadState);
+    void notifyKill(GenericRobot* killer, GenericRobot* victim);
     RobotPtrIterator getRobotIterator(GenericRobot* robot);
 
     void applyRobotUpgrades();

--- a/src/environment.h
+++ b/src/environment.h
@@ -95,7 +95,7 @@ public:
     void applyRobotRespawn();
     void applyRobotDie();
 
-    vector<GenericRobot*> getAllRobots() const;
+    const vector<GenericRobot*> getAllAvailableRobots() const;
 };
 
 #endif  // ENVIRONMENT_H

--- a/src/genericRobot.cpp
+++ b/src/genericRobot.cpp
@@ -205,6 +205,10 @@ Vector2D GenericRobot::getPosition() const {
     return position;
 }
 
+void GenericRobot::setPosition(Vector2D pos) {
+    this->position = pos;
+}
+
 // No upgrades, so return empty vector
 const vector<Upgrade>& GenericRobot::getUpgrades() const {
     return upgrades;
@@ -304,8 +308,4 @@ UpgradeState GenericRobot::chosenForUpgrade() {
 
 void GenericRobot::notifyRespawn() {
     livingState = Alive;
-}
-
-void GenericRobot::notifyUpgradesCompleted() {
-    pendingUpgrades.clear();
 }

--- a/src/genericRobot.cpp
+++ b/src/genericRobot.cpp
@@ -1,6 +1,7 @@
 #include <cstdint>
 #include <cmath>
 #include <random>
+#include <sstream>
 #include <string>
 #include <vector>
 #include <algorithm>
@@ -42,6 +43,10 @@ void GenericRobot::die() {
 
     respawnCountLeft--;
     livingState = PendingRespawn;
+
+    ostringstream ss;
+    ss << "Robot " << name << " will respawn later (Respawn count left: " << respawnCountLeft << ")";
+    selfLog(ss.str());
 }
 
 void GenericRobot::thinkAndExecute() {

--- a/src/genericRobot.cpp
+++ b/src/genericRobot.cpp
@@ -189,6 +189,10 @@ char GenericRobot::getSymbol() const {
     return this->symbol;
 }
 
+LivingState GenericRobot::getLivingState() const {
+    return this->livingState;
+}
+
 bool GenericRobot::isDead() const {
     return livingState != Alive;
 }

--- a/src/genericRobot.cpp
+++ b/src/genericRobot.cpp
@@ -305,3 +305,7 @@ UpgradeState GenericRobot::chosenForUpgrade() {
 void GenericRobot::notifyRespawn() {
     livingState = Alive;
 }
+
+void GenericRobot::notifyUpgradesCompleted() {
+    pendingUpgrades.clear();
+}

--- a/src/genericRobot.cpp
+++ b/src/genericRobot.cpp
@@ -301,3 +301,7 @@ UpgradeState GenericRobot::chosenForUpgrade() {
 
     return AvailableForUpgrade;
 }
+
+void GenericRobot::notifyRespawn() {
+    livingState = Alive;
+}

--- a/src/genericRobot.h
+++ b/src/genericRobot.h
@@ -55,7 +55,6 @@ public:
 
     UpgradeState chosenForUpgrade();
     void notifyRespawn();
-    void notifyUpgradesCompleted();
 
     string getName() const override;
     Vector2D getPosition() const override;
@@ -71,6 +70,7 @@ public:
     char getSymbol() const override;
     void logUpgrades();
 
+    void setPosition(Vector2D pos);
 
 protected:
     // These will have to be initialized

--- a/src/genericRobot.h
+++ b/src/genericRobot.h
@@ -34,6 +34,12 @@ enum UpgradeState {
     UpgradeFull
 };
 
+// Robot life state
+enum LivingState {
+    Alive,
+    Dead,
+    PendingRespawn
+};
 
 class GenericRobot : public MovingRobot, public ThinkingRobot, public SeeingRobot, public ShootingRobot {
 public:
@@ -44,8 +50,9 @@ public:
         Logger* logger
     );
 
-    DeadState die() override;
+    void die() override;
     void thinkAndExecute() override;
+
     UpgradeState chosenForUpgrade();
 
     string getName() const override;
@@ -53,7 +60,7 @@ public:
     const vector<Upgrade>& getPendingUpgrades() const;
     const vector<Upgrade>& getUpgrades() const;
     void insertNewUpgrade(const Upgrade& upgrade);
-    bool getIsDead() const;
+    bool isDead() const;
     bool getIsVisible() const;
 
     // Print the map grid with robot positions and cardinal directions
@@ -70,7 +77,7 @@ protected:
     int respawnCountLeft = 3;
     vector<int> movementRange={-1,1};
     bool isVisible = true;
-    bool isDead = false;
+    LivingState livingState = Alive;
 
     Environment* environment;
     Logger* logger;

--- a/src/genericRobot.h
+++ b/src/genericRobot.h
@@ -55,6 +55,7 @@ public:
 
     UpgradeState chosenForUpgrade();
     void notifyRespawn();
+    void notifyUpgradesCompleted();
 
     string getName() const override;
     Vector2D getPosition() const override;

--- a/src/genericRobot.h
+++ b/src/genericRobot.h
@@ -54,6 +54,7 @@ public:
     void thinkAndExecute() override;
 
     UpgradeState chosenForUpgrade();
+    void notifyRespawn();
 
     string getName() const override;
     Vector2D getPosition() const override;

--- a/src/genericRobot.h
+++ b/src/genericRobot.h
@@ -62,6 +62,7 @@ public:
     void insertNewUpgrade(const Upgrade& upgrade);
     bool isDead() const;
     bool getIsVisible() const;
+    LivingState getLivingState() const;
 
     // Print the map grid with robot positions and cardinal directions
     // Assumes Environment will call this and provide access to all robots

--- a/src/upgrades/scoutBot.cpp
+++ b/src/upgrades/scoutBot.cpp
@@ -5,7 +5,7 @@ vector<Vector2D> ScoutBot::scout(){
     vector<Vector2D> scoutedBots;
     selfLog("Scouting the environment.");
     // gets all the robots in env, and iterates through each of em
-    for (const auto& robot : environment->getAllRobots()) {
+    for (const auto& robot : environment->getAllAvailableRobots()) {
         Vector2D pos = robot->getPosition();
         Vector2D selfPos = this->getPosition();
         Vector2D relativePosition = pos - selfPos;


### PR DESCRIPTION
- Make the respawn / dying robot finally robust (no more memory corruption)
- Remove pending upgrades after upgrade
- Replace dead state with actual alive / dead state
- Clear robotsToUpgrade after upgrade cycle
- Move alive / dead state handling to genericRobot
- vrooom vrooom
- Notify the robot on respawn
- Make robot respawn
- Make robot fking die